### PR TITLE
Issue #51 : Use separate password_resets_table for each

### DIFF
--- a/src/Commands/MultiAuthInstallCommand.php
+++ b/src/Commands/MultiAuthInstallCommand.php
@@ -73,6 +73,7 @@ class MultiAuthInstallCommand extends InstallAndReplaceCommand
                 ]);
 
                 $this->installMigration();
+                $this->installPasswordResetMigration();
             }
 
             if(!$this->option('views')) {
@@ -175,6 +176,35 @@ class MultiAuthInstallCommand extends InstallAndReplaceCommand
         }
 
         $path = $migrationDir . date('Y_m_d_His') . '_' . $migrationName;
+        $this->putFile($path, $migrationStub);
+
+        return true;
+    }
+
+    /**
+     * Install PasswordResetMigration.
+     *
+     * @return bool
+     */
+    public function installPasswordResetMigration()
+    {
+        $name = $this->getParsedNameInput();
+
+        $migrationDir = base_path() . '/database/migrations/';
+        $migrationName = 'create_' . str_singular(snake_case($name)) .'_password_resets_table.php';
+        $migrationStub = new SplFileInfo(__DIR__ . '/../stubs/Model/PasswordResetMigration.stub');
+
+        $files = $this->files->allFiles($migrationDir);
+
+        foreach ($files as $file) {
+            if(str_contains($file->getFilename(), $migrationName)) {
+                $this->putFile($file->getPathname(), $migrationStub);
+
+                return true;
+            }
+        }
+
+        $path = $migrationDir . date('Y_m_d_His', strtotime('+1 second')) . '_' . $migrationName;
         $this->putFile($path, $migrationStub);
 
         return true;

--- a/src/stubs/Model/PasswordResetMigration.stub
+++ b/src/stubs/Model/PasswordResetMigration.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Create{{singularClass}}PasswordResetsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{singularSnake}}_password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token')->index();
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('{{singularSnake}}_password_resets');
+    }
+}

--- a/src/stubs/config/passwords.stub
+++ b/src/stubs/config/passwords.stub
@@ -1,6 +1,6 @@
 
         '{{pluralSnake}}' => [
             'provider' => '{{pluralSnake}}',
-            'table' => 'password_resets',
+            'table' => '{{singularSnake}}_password_resets',
             'expire' => 60,
         ],


### PR DESCRIPTION
I have tested and solved the requirement in Issue #51 .

Used +1 second in generation of password_resets file, to keep timestamp on files different.